### PR TITLE
feat: copy prompts to clipboard

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -9,6 +9,7 @@ from datetime import datetime
 
 import click
 import platform
+import pyperclip
 
 from prompt_template import react_system_prompt_template
 
@@ -121,10 +122,17 @@ class ReActAgent:
             "messages": messages
         }
 
+        request_json = json.dumps(request_payload, indent=2, ensure_ascii=False)
+
         log_and_print(f"\n" + "="*80, self.log_file)
         log_and_print(f"📋 EXACT JSON REQUEST (copy-paste to a web LLM)", self.log_file)
         log_and_print(f"="*80, self.log_file)
-        log_and_print(json.dumps(request_payload, indent=2, ensure_ascii=False), self.log_file)
+        log_and_print(request_json, self.log_file)
+        try:
+            pyperclip.copy(request_json)
+            log_and_print("Prompt copied to clipboard.", self.log_file)
+        except pyperclip.PyperclipException as e:
+            log_and_print(f"Failed to copy prompt to clipboard: {e}", self.log_file)
         log_and_print(f"="*80 + "\n", self.log_file)
 
         log_and_print("Please paste the model's response. End with a line containing only END.", self.log_file)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ requires-python = ">=3.12"
 dependencies = [
     "click>=8.2.1",
     "requests>=2.31.0",
+    "pyperclip>=1.8.2",
 ]
 
 [tool.uv.workspace]


### PR DESCRIPTION
## Summary
- copy model request payloads to clipboard for easy pasting
- require pyperclip as a standard dependency

## Testing
- `pip install pyperclip` *(fails: Could not find a version that satisfies the requirement pyperclip (proxy 403))*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c2fc68013483289eb7b0ba781e133a