### PR TITLE
Add manual mode for LLM interactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,20 @@ After ensuring `uv` is installed successfully, navigate to the current directory
 uv run agent.py <project_directory>
 ```
 
+### Manual mode
+
+If you prefer to run the model call manually (for example, by pasting the request
+payload into a browser-based LLM), start the agent with the `--manual` flag:
+
+```bash
+uv run agent.py --manual <project_directory>
+```
+
+For each step, the agent copies the exact JSON payload for the model request to
+your clipboard. Paste that payload into your chosen LLM, then copy the model's
+response and paste it back into the terminal, ending your input with a line that
+contains only `END`.
+
 ### Example Usage
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "python-dotenv>=1.1.1",
     "requests>=2.31.0",
     "duckduckgo-search>=6.3.0",
+    "pyperclip>=1.9.0",
 ]
 
 [tool.uv.workspace]


### PR DESCRIPTION
## Summary
- add a manual interaction mode that copies each request payload to the clipboard and accepts pasted responses
- expose the manual mode via the `--manual` CLI flag and document the workflow in the README
- add a clipboard dependency needed to support copying JSON payloads

## Testing
- `uv run python -m compileall .` *(fails: Failed to fetch https://pypi.org/simple/click/ due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68cc6bde2c2883289cd4993f3aea4a9d